### PR TITLE
Add free space confidence with predicted class labels

### DIFF
--- a/infer_ros.py
+++ b/infer_ros.py
@@ -80,7 +80,10 @@ class ROSInfer:
             y_pred = self.net(x_depth=x_depth, x_rgb=x_rgb, p=position)
 
         scores = torch.nn.Softmax(dim=0)(y_pred.squeeze())
-        preds = torch.argmax(scores, dim=0).cpu().numpy()
+        free_space_confidence = scores[0]
+        
+        # Encode free space scores along with class id.
+        preds = torch.argmax(scores, dim=0).cpu().numpy() + free_space_confidence.detach().cpu().numpy()
 
         # setup message
         msg = SSCGrid()

--- a/infer_ros.py
+++ b/infer_ros.py
@@ -80,6 +80,9 @@ class ROSInfer:
             y_pred = self.net(x_depth=x_depth, x_rgb=x_rgb, p=position)
 
         scores = torch.nn.Softmax(dim=0)(y_pred.squeeze())
+        # Threshold max probs for encoding free space
+        max_prob = 1.0 - 1e-8
+        scores[scores> max_prob] = max_prob
         free_space_confidence = scores[0]
         
         # Encode free space scores along with class id.


### PR DESCRIPTION
Encode free space scores along with class id. e.g If maximum scoring class is assume class 2 (with confidence say 0.7), others excluding free_space (0.2) and free space confidence 0.1 then the encoded value would be 2.1. The collective probability is obtained by subtracting free prob from 1 which in this case would be 0.9.
This optimization saves an expensive transfer for per class scores. Hint: 0<= confidence interval <= prob_threshold(0.99999999)